### PR TITLE
feat(RHOAIENG-31379): Add Llama Stack build automation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -20,3 +20,4 @@ Llama Stack uses GitHub Actions for Continous Integration (CI). Below is a table
 | Test External API and Providers | [test-external.yml](test-external.yml) | Test the External API and Provider mechanisms |
 | Unit Tests | [unit-tests.yml](unit-tests.yml) | Run the unit test suite |
 | Update ReadTheDocs | [update-readthedocs.yml](update-readthedocs.yml) | Update the Llama Stack ReadTheDocs site |
+| Build and Push Docker Image | [docker-build.yml](docker-build.yml) | Build and push Docker image to quay.io/trustyai/llama-stack:latest on PR merge |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,57 @@
+name: Build and Push Docker Image
+
+run-name: Build and push llama-stack image to quay.io
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install dependencies
+        uses: ./.github/actions/setup-runner
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Log in to Quay
+        run: docker login -u ${{ secrets.QUAY_ROBOT_USERNAME }} -p ${{ secrets.QUAY_ROBOT_SECRET }} quay.io
+
+      - name: Build and push Docker image
+        run: |
+          # Build the trustyai distribution using llama stack build
+          USE_COPY_NOT_MOUNT=true LLAMA_STACK_DIR=. uv run llama stack build \
+            --config trustyai-distribution/build.yaml \
+            --image-type container \
+            --image-name quay.io/trustyai/llama-stack:latest
+          
+          # Also tag with commit SHA for versioning
+          docker tag quay.io/trustyai/llama-stack:latest quay.io/trustyai/llama-stack:${{ github.sha }}
+          
+          # Push both images
+          docker push quay.io/trustyai/llama-stack:latest
+          docker push quay.io/trustyai/llama-stack:${{ github.sha }}
+
+      - name: Verify image
+        run: |
+          # Test that the image can start
+          docker run --rm quay.io/trustyai/llama-stack:latest python -c "import llama_stack; print('Image verification successful')"
+          
+          # Test that the server can start (basic functionality check)
+          timeout 30s docker run --rm quay.io/trustyai/llama-stack:latest python -m llama_stack.distribution.server.server --help || true 


### PR DESCRIPTION
## What does this PR do?

Add image build automation for each PR.

## Summary by Sourcery

Introduce a GitHub Actions workflow that automatically builds, tags, and publishes llama-stack Docker images to Quay upon merging pull requests, and document this new process in the CI README.

CI:
- Add GitHub Actions workflow to build, tag, and push llama-stack Docker images to quay.io on pull request merge

Documentation:
- Update CI workflows README to include the new Docker build and push action