### PR TITLE
refactor: update trustyai distro with latest changes from ODH LLS RH distro

### DIFF
--- a/llama_stack/providers/registry/vector_io.py
+++ b/llama_stack/providers/registry/vector_io.py
@@ -521,7 +521,7 @@ Please refer to the inline provider documentation.
             Api.vector_io,
             AdapterSpec(
                 adapter_type="milvus",
-                pip_packages=["pymilvus"],
+                pip_packages=["pymilvus>=2.4.10"],
                 module="llama_stack.providers.remote.vector_io.milvus",
                 config_class="llama_stack.providers.remote.vector_io.milvus.MilvusVectorIOConfig",
                 description="""
@@ -634,7 +634,7 @@ For more details on TLS configuration, refer to the [TLS setup guide](https://mi
         InlineProviderSpec(
             api=Api.vector_io,
             provider_type="inline::milvus",
-            pip_packages=["pymilvus"],
+            pip_packages=["pymilvus>=2.4.10"],
             module="llama_stack.providers.inline.vector_io.milvus",
             config_class="llama_stack.providers.inline.vector_io.milvus.MilvusVectorIOConfig",
             api_dependencies=[Api.inference],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ unit = [
     "sqlalchemy[asyncio]>=2.0.41",
     "blobfile",
     "faiss-cpu",
-    "pymilvus",
+    "pymilvus>=2.5.12",
     "litellm",
     "together",
     "coverage",
@@ -113,7 +113,7 @@ test = [
     "sqlalchemy",
     "sqlalchemy[asyncio]>=2.0.41",
     "requests",
-    "pymilvus",
+    "pymilvus>=2.5.12",
     "reportlab",
 ]
 docs = [

--- a/trustyai-distribution/Containerfile
+++ b/trustyai-distribution/Containerfile
@@ -11,26 +11,20 @@ RUN pip install \
     aiosqlite \
     autoevals \
     chardet \
-    datasets \
+    'datasets>=4.0.0' \
     fastapi \
     fire \
-    garak==0.12.0 \
     httpx \
-    kubernetes \
-    llama_stack_provider_lmeval==0.1.7 \
-    llama_stack_provider_trustyai_fms==0.1.4 \
-    llama_stack_provider_trustyai_garak==0.1.1 \
     matplotlib \
-    mcp>=1.8.1 \
+    'mcp>=1.8.1' \
     nltk \
     numpy \
-    openai \
     opentelemetry-exporter-otlp-proto-http \
     opentelemetry-sdk \
     pandas \
     pillow \
     psycopg2-binary \
-    pymilvus \
+    'pymilvus[milvus-lite]>=2.4.10' \
     pymongo \
     pypdf \
     redis \
@@ -42,14 +36,21 @@ RUN pip install \
     tqdm \
     transformers \
     uvicorn
-RUN pip install --index-url https://download.pytorch.org/whl/cpu torch torchvision
+RUN pip install \
+    llama_stack_provider_lmeval==0.2.4
+RUN pip install \
+    llama_stack_provider_trustyai_fms==0.2.2
+RUN pip install \
+    llama_stack_provider_trustyai_garak==0.1.4
+RUN pip install \
+    llama_stack_provider_trustyai_garak[remote]==0.1.4
+RUN pip install --extra-index-url https://download.pytorch.org/whl/cpu torch 'torchao>=0.12.0' torchvision
 RUN pip install --no-deps sentence-transformers
-RUN pip install --no-cache llama-stack==0.2.16
+RUN pip install --no-cache llama-stack==0.2.22
 
 # Switch back to non-root user
 USER 1001
-RUN mkdir -p ${HOME}/.llama/providers.d ${HOME}/.cache
+RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY trustyai-distribution/run.yaml ${APP_ROOT}/run.yaml
-COPY trustyai-distribution/providers.d/ ${HOME}/.llama/providers.d/
 
-ENTRYPOINT ["python", "-m", "llama_stack.distribution.server.server", "--config", "/opt/app-root/run.yaml"]
+ENTRYPOINT ["python", "-m", "llama_stack.core.server.server", "/opt/app-root/run.yaml"]

--- a/trustyai-distribution/Containerfile
+++ b/trustyai-distribution/Containerfile
@@ -9,6 +9,7 @@ USER root
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
 RUN pip install \
     aiosqlite \
+    asyncpg \
     autoevals \
     chardet \
     'datasets>=4.0.0' \
@@ -39,6 +40,10 @@ RUN pip install \
 RUN pip install \
     llama_stack_provider_lmeval==0.2.4
 RUN pip install \
+    llama_stack_provider_ragas==0.3.0
+RUN pip install \
+    llama_stack_provider_ragas[remote]==0.3.0
+RUN pip install \
     llama_stack_provider_trustyai_fms==0.2.2
 RUN pip install \
     llama_stack_provider_trustyai_garak==0.1.4
@@ -48,6 +53,8 @@ RUN pip install --extra-index-url https://download.pytorch.org/whl/cpu torch 'to
 RUN pip install --no-deps sentence-transformers
 RUN pip install --no-cache llama-stack==0.2.22
 
+# chown the work directories to the non-root user to create garak scan log files
+RUN chown -R 1001:1001 ${APP_ROOT}
 # Switch back to non-root user
 USER 1001
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache

--- a/trustyai-distribution/Containerfile.in
+++ b/trustyai-distribution/Containerfile.in
@@ -5,12 +5,11 @@ WORKDIR /opt/app-root
 USER root
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
 {dependencies}
-RUN pip install --no-cache llama-stack==0.2.16
+RUN pip install --no-cache llama-stack==0.2.22
 
 # Switch back to non-root user
 USER 1001
-RUN mkdir -p ${{HOME}}/.llama/providers.d ${{HOME}}/.cache
+RUN mkdir -p ${{HOME}}/.llama ${{HOME}}/.cache
 COPY trustyai-distribution/run.yaml ${{APP_ROOT}}/run.yaml
-COPY trustyai-distribution/providers.d/ ${{HOME}}/.llama/providers.d/
 
-ENTRYPOINT ["python", "-m", "llama_stack.distribution.server.server", "--config", "/opt/app-root/run.yaml"]
+ENTRYPOINT ["python", "-m", "llama_stack.core.server.server", "/opt/app-root/run.yaml"]

--- a/trustyai-distribution/Containerfile.in
+++ b/trustyai-distribution/Containerfile.in
@@ -7,6 +7,8 @@ RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
 {dependencies}
 RUN pip install --no-cache llama-stack==0.2.22
 
+# chown the work directories to the non-root user to create garak scan log files
+RUN chown -R 1001:1001 ${{APP_ROOT}}
 # Switch back to non-root user
 USER 1001
 RUN mkdir -p ${{HOME}}/.llama ${{HOME}}/.cache

--- a/trustyai-distribution/build.py
+++ b/trustyai-distribution/build.py
@@ -13,7 +13,7 @@ import sys
 from pathlib import Path
 
 BASE_REQUIREMENTS = [
-    "llama-stack==0.2.16",
+    "llama-stack==0.2.22",
 ]
 
 
@@ -76,8 +76,24 @@ def get_dependencies():
                     cmd_parts = parts[:3]  # "RUN pip install"
                     packages = sorted(set(parts[3].split()))  # Sort the package names and remove duplicates
 
+                    # Add quotes to packages with > or < to prevent bash redirection
+                    packages = [
+                        f"'{package}'"
+                        if (">" in package or "<" in package)
+                        else package
+                        for package in packages
+                    ]
+
+                    # Modify pymilvus package to include milvus-lite extra
+                    packages = [
+                        package.replace("pymilvus", "pymilvus[milvus-lite]")
+                        if "pymilvus" in package
+                        else package
+                        for package in packages
+                    ]
+
                     # Determine command type and format accordingly
-                    if "--index-url" in line:
+                    if ("--index-url" in line) or ("--extra-index-url" in line):
                         full_cmd = " ".join(cmd_parts + [" ".join(packages)])
                         torch_deps.append(full_cmd)
                     elif "--no-deps" in line:
@@ -104,6 +120,7 @@ def get_dependencies():
     except subprocess.CalledProcessError as e:
         print(f"Error executing command: {e}")
         print(f"Command output: {e.output}")
+        print(f"Command stderr: {e.stderr}")
         sys.exit(1)
 
 

--- a/trustyai-distribution/build.yaml
+++ b/trustyai-distribution/build.yaml
@@ -9,11 +9,16 @@ distribution_spec:
     - provider_type: inline::milvus
     safety:
     - provider_type: remote::trustyai_fms
+      module: llama_stack_provider_trustyai_fms==0.2.2
     agents:
     - provider_type: inline::meta-reference
     eval:
     - provider_type: remote::trustyai_lmeval
+      module: llama_stack_provider_lmeval==0.2.4
     - provider_type: inline::trustyai_garak
+      module: llama_stack_provider_trustyai_garak==0.1.4
+    - provider_type: remote::trustyai_garak
+      module: llama_stack_provider_trustyai_garak[remote]==0.1.4
     datasetio:
     - provider_type: remote::huggingface
     - provider_type: inline::localfs

--- a/trustyai-distribution/build.yaml
+++ b/trustyai-distribution/build.yaml
@@ -19,6 +19,10 @@ distribution_spec:
       module: llama_stack_provider_trustyai_garak==0.1.4
     - provider_type: remote::trustyai_garak
       module: llama_stack_provider_trustyai_garak[remote]==0.1.4
+    - provider_type: inline::trustyai_ragas
+      module: llama_stack_provider_ragas==0.3.0
+    - provider_type: remote::trustyai_ragas
+      module: llama_stack_provider_ragas[remote]==0.3.0
     datasetio:
     - provider_type: remote::huggingface
     - provider_type: inline::localfs
@@ -33,10 +37,14 @@ distribution_spec:
     - provider_type: remote::tavily-search
     - provider_type: inline::rag-runtime
     - provider_type: remote::model-context-protocol
+    files:
+    - provider_type: inline::localfs
   container_image: registry.access.redhat.com/ubi9/python-312:latest
 additional_pip_packages:
 - aiosqlite
 - sqlalchemy[asyncio]
+- asyncpg
+- psycopg2-binary
 image_type: container
 image_name: llama-stack-trustyai
-external_providers_dir: trustyai-distribution/providers.d
+# external_providers_dir: trustyai-distribution/providers.d

--- a/trustyai-distribution/run.yaml
+++ b/trustyai-distribution/run.yaml
@@ -80,7 +80,7 @@ providers:
         namespace: ${env.KUBEFLOW_NAMESPACE:=model-namespace}
         experiment_name: ${env.KUBEFLOW_EXPERIMENT_NAME:=trustyai-garak-scans}
         base_image: ${env.KUBEFLOW_BASE_IMAGE:=quay.io/rh-ee-spandraj/trustyai-garak-provider-dsp:cpu}
-  - provider_id: trustyai_ragas_inline
+  - provider_id: trustyai_ragas
     provider_type: inline::trustyai_ragas
     module: llama_stack_provider_ragas.inline
     config:

--- a/trustyai-distribution/run.yaml
+++ b/trustyai-distribution/run.yaml
@@ -85,7 +85,7 @@ providers:
     module: llama_stack_provider_ragas.inline
     config:
       embedding_model: ${env.EMBEDDING_MODEL}
-  - provider_id: trustyai_ragas_remote
+  - provider_id: trustyai_ragas
     provider_type: remote::trustyai_ragas
     module: llama_stack_provider_ragas
     config:

--- a/trustyai-distribution/run.yaml
+++ b/trustyai-distribution/run.yaml
@@ -80,6 +80,23 @@ providers:
         namespace: ${env.KUBEFLOW_NAMESPACE:=model-namespace}
         experiment_name: ${env.KUBEFLOW_EXPERIMENT_NAME:=trustyai-garak-scans}
         base_image: ${env.KUBEFLOW_BASE_IMAGE:=quay.io/rh-ee-spandraj/trustyai-garak-provider-dsp:cpu}
+  - provider_id: trustyai_ragas_inline
+    provider_type: inline::trustyai_ragas
+    module: llama_stack_provider_ragas.inline
+    config:
+      embedding_model: ${env.EMBEDDING_MODEL}
+  - provider_id: trustyai_ragas_remote
+    provider_type: remote::trustyai_ragas
+    module: llama_stack_provider_ragas
+    config:
+      embedding_model: ${env.EMBEDDING_MODEL}
+      kubeflow_config:
+        results_s3_prefix: ${env.KUBEFLOW_RESULTS_S3_PREFIX}
+        s3_credentials_secret_name: ${env.KUBEFLOW_S3_CREDENTIALS_SECRET_NAME}
+        pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT}
+        namespace: ${env.KUBEFLOW_NAMESPACE}
+        llama_stack_url: ${env.KUBEFLOW_LLAMA_STACK_URL}
+        base_image: ${env.KUBEFLOW_BASE_IMAGE}
   datasetio:
   - provider_id: huggingface
     provider_type: remote::huggingface

--- a/trustyai-distribution/run.yaml
+++ b/trustyai-distribution/run.yaml
@@ -36,6 +36,7 @@ providers:
   safety:
     - provider_id: trustyai_fms
       provider_type: remote::trustyai_fms
+      module: llama_stack_provider_trustyai_fms==0.2.2
       config:
         orchestrator_url: ${env.FMS_ORCHESTRATOR_URL:=}
         ssl_cert_path: ${env.FMS_SSL_CERT_PATH:=}
@@ -54,16 +55,31 @@ providers:
   eval:
   - provider_id: trustyai_lmeval
     provider_type: remote::trustyai_lmeval
+    module: llama_stack_provider_lmeval==0.2.4
     config:
-        use_k8s: True
+        use_k8s: ${env.TRUSTYAI_LMEVAL_USE_K8S:=true}
         base_url: ${env.VLLM_URL:=http://localhost:8000/v1}
-  - provider_id: trustyai_garak
+  - provider_id: trustyai_garak_inline
     provider_type: inline::trustyai_garak
+    module: llama_stack_provider_trustyai_garak.inline
     config:
       base_url: ${env.BASE_URL:=http://localhost:8321/v1} # llama-stack service base url
       timeout: ${env.GARAK_TIMEOUT:=10800}
       max_concurrent_jobs: ${env.GARAK_MAX_CONCURRENT_JOBS:=5}
       tls_verify: ${env.GARAK_TLS_VERIFY:=true}
+  - provider_id: trustyai_garak_remote
+    provider_type: remote::trustyai_garak
+    module: llama_stack_provider_trustyai_garak.remote
+    config:
+      base_url: ${env.BASE_URL:=https://c11deb30887f.ngrok-free.app/v1} # llama-stack service base url (must be accessible from kf pods)
+      timeout: ${env.GARAK_TIMEOUT:=10800}
+      max_concurrent_jobs: ${env.GARAK_MAX_CONCURRENT_JOBS:=5}
+      tls_verify: ${env.GARAK_TLS_VERIFY:=true}
+      kubeflow_config:
+        pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT:=https://ds-pipeline-dspa-model-namespace.apps.rosa.y1m4j9o2e1n6b9l.r6mx.p3.openshiftapps.com}
+        namespace: ${env.KUBEFLOW_NAMESPACE:=model-namespace}
+        experiment_name: ${env.KUBEFLOW_EXPERIMENT_NAME:=trustyai-garak-scans}
+        base_image: ${env.KUBEFLOW_BASE_IMAGE:=quay.io/rh-ee-spandraj/trustyai-garak-provider-dsp:cpu}
   datasetio:
   - provider_id: huggingface
     provider_type: remote::huggingface
@@ -144,42 +160,42 @@ shields: []
 vector_dbs: []
 datasets: []
 scoring_fns: []
-benchmarks:
-- benchmark_id: quick
+benchmarks: # TODO: Can a single benchmark be used for both inline and remote garak providers?
+- benchmark_id: trustyai_garak::quick
   dataset_id: garak
   scoring_functions:
     - garak_scoring
-  provider_id: trustyai_garak
+  provider_id: trustyai_garak_remote
   provider_benchmark_id: quick
-- benchmark_id: standard
+- benchmark_id: trustyai_garak::standard
   dataset_id: garak
   scoring_functions:
     - garak_scoring
-  provider_id: trustyai_garak
+  provider_id: trustyai_garak_remote
   provider_benchmark_id: standard
-- benchmark_id: owasp_llm_top10
+- benchmark_id: trustyai_garak::owasp_llm_top10
   dataset_id: garak
   scoring_functions:
     - garak_scoring
-  provider_id: trustyai_garak
+  provider_id: trustyai_garak_remote
   provider_benchmark_id: owasp_llm_top10
-- benchmark_id: avid_security
+- benchmark_id: trustyai_garak::avid_security
   dataset_id: garak
   scoring_functions:
     - garak_scoring
-  provider_id: trustyai_garak
+  provider_id: trustyai_garak_remote
   provider_benchmark_id: avid_security
-- benchmark_id: avid_ethics
+- benchmark_id: trustyai_garak::avid_ethics
   dataset_id: garak
   scoring_functions:
     - garak_scoring
-  provider_id: trustyai_garak
+  provider_id: trustyai_garak_remote
   provider_benchmark_id: avid_ethics
-- benchmark_id: avid_performance
+- benchmark_id: trustyai_garak::avid_performance
   dataset_id: garak
   scoring_functions:
     - garak_scoring
-  provider_id: trustyai_garak
+  provider_id: trustyai_garak_remote
   provider_benchmark_id: avid_performance
 tool_groups:
 - toolgroup_id: builtin::websearch
@@ -188,4 +204,4 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-external_providers_dir: /opt/app-root/src/.llama/providers.d
+# external_providers_dir: /opt/app-root/src/.llama/providers.d


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
- revert the previous pymilvus conflict changes as this is resolved with latest pymilvus release
- sync with midstream odh LLS RH distro 
- specify `module:` instead of using `external_providers_dir`
- include remote garak feature

## Summary by Sourcery

Sync trustyai distribution with the latest ODH LLS RH midstream changes by upgrading core and provider versions, switching to module-based provider configuration, adding a remote Garak provider with benchmarks, and streamlining pip install handling.

New Features:
- Add remote trustyai_garak provider with Kubeflow configuration and update benchmarks accordingly

Bug Fixes:
- Revert previous pymilvus conflict workaround now addressed by upgrading to latest pymilvus release

Enhancements:
- Bump llama-stack and provider module versions across Containerfile, build.yaml, and build.py
- Switch to specifying provider modules directly instead of using external_providers_dir
- Split and refine pip install commands for providers and update dependencies (datasets, torch, torchao)
- Refactor build.py to quote version constraints, include pymilvus extras, and surface stderr logs

Build:
- Update Containerfile and build.yaml to align with midstream ODH LLS RH distro