### PR TITLE
fix: Add FMS 0.2.3 for AdapterSpec fix, temporary Garak permission fixes

### DIFF
--- a/trustyai-distribution/Containerfile
+++ b/trustyai-distribution/Containerfile
@@ -44,7 +44,7 @@ RUN pip install \
 RUN pip install \
     llama_stack_provider_ragas[remote]==0.3.0
 RUN pip install \
-    llama_stack_provider_trustyai_fms==0.2.2
+    --extra-index-url https://test.pypi.org/simple/ llama_stack_provider_trustyai_fms==0.2.3
 RUN pip install \
     llama_stack_provider_trustyai_garak==0.1.4
 RUN pip install \
@@ -55,6 +55,13 @@ RUN pip install --no-cache llama-stack==0.2.22
 
 # chown the work directories to the non-root user to create garak scan log files
 RUN chown -R 1001:1001 ${APP_ROOT}
+# Make the Garak provider package directory writable for scan files
+RUN mkdir -p /opt/app-root/lib64/python3.12/site-packages/llama_stack_provider_trustyai_garak/_scan_files && \
+    chown -R 1001:1001 /opt/app-root/lib64/python3.12/site-packages/llama_stack_provider_trustyai_garak
+# Create Garak directories with full permissions (world-writable for debugging)
+RUN mkdir -p ${APP_ROOT}/src/.config/garak ${APP_ROOT}/src/.local/share/garak ${APP_ROOT}/src/.cache/garak/resources && \
+    chmod -R 777 ${APP_ROOT}/src/.config ${APP_ROOT}/src/.local ${APP_ROOT}/src/.cache && \
+    chown -R 1001:0 ${APP_ROOT}/src/.config ${APP_ROOT}/src/.local ${APP_ROOT}/src/.cache
 # Switch back to non-root user
 USER 1001
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache

--- a/trustyai-distribution/Containerfile.in
+++ b/trustyai-distribution/Containerfile.in
@@ -9,6 +9,14 @@ RUN pip install --no-cache llama-stack==0.2.22
 
 # chown the work directories to the non-root user to create garak scan log files
 RUN chown -R 1001:1001 ${{APP_ROOT}}
+# FIXME: Temporary fix for Garak's permissions
+# Make the Garak provider package directory writable for scan files
+RUN mkdir -p /opt/app-root/lib64/python3.12/site-packages/llama_stack_provider_trustyai_garak/_scan_files && \
+    chown -R 1001:1001 /opt/app-root/lib64/python3.12/site-packages/llama_stack_provider_trustyai_garak
+# Create Garak directories with full permissions (world-writable for debugging)
+RUN mkdir -p ${{APP_ROOT}}/src/.config/garak ${{APP_ROOT}}/src/.local/share/garak ${{APP_ROOT}}/src/.cache/garak/resources && \
+    chmod -R 777 ${{APP_ROOT}}/src/.config ${{APP_ROOT}}/src/.local ${{APP_ROOT}}/src/.cache && \
+    chown -R 1001:0 ${{APP_ROOT}}/src/.config ${{APP_ROOT}}/src/.local ${{APP_ROOT}}/src/.cache
 # Switch back to non-root user
 USER 1001
 RUN mkdir -p ${{HOME}}/.llama ${{HOME}}/.cache

--- a/trustyai-distribution/build.py
+++ b/trustyai-distribution/build.py
@@ -116,7 +116,15 @@ def get_dependencies():
         all_deps.extend(sorted(no_deps))  # No-deps installs
         all_deps.extend(sorted(no_cache))  # No-cache installs
 
-        return "\n".join(all_deps)
+        # TODO: Remove this once we have a stable PyPI index for trustyai_fms
+        # Fix trustyai_fms package to use test PyPI index
+        result = "\n".join(all_deps)
+        result = result.replace(
+            "llama_stack_provider_trustyai_fms==0.2.3",
+            "--extra-index-url https://test.pypi.org/simple/ llama_stack_provider_trustyai_fms==0.2.3",
+        )
+        return result
+
     except subprocess.CalledProcessError as e:
         print(f"Error executing command: {e}")
         print(f"Command output: {e.output}")

--- a/trustyai-distribution/build.yaml
+++ b/trustyai-distribution/build.yaml
@@ -9,7 +9,7 @@ distribution_spec:
     - provider_type: inline::milvus
     safety:
     - provider_type: remote::trustyai_fms
-      module: llama_stack_provider_trustyai_fms==0.2.2
+      module: llama_stack_provider_trustyai_fms==0.2.3
     agents:
     - provider_type: inline::meta-reference
     eval:


### PR DESCRIPTION
# What does this PR do?

* Temporarily use FMS test/0.2.3 to bring `AdapterSpec` changes until 0.2.3 is published
* Temporarily fix Garak's folder permissions

## Summary by Sourcery

Temporarily pin trustyai_fms dependency to version 0.2.3 on the Test PyPI index and apply Garak provider folder permission fixes

Bug Fixes:
- Adjust ownership and permissions for Garak provider scan, config, and cache directories

Enhancements:
- Pin trustyai_fms to version 0.2.3 using the Test PyPI index in build script, Containerfile, and build.yaml