### PR TITLE
Update TrustyAI LLS distro with latest providers & LLS

### DIFF
--- a/trustyai-distribution/Containerfile
+++ b/trustyai-distribution/Containerfile
@@ -4,20 +4,24 @@
 FROM registry.access.redhat.com/ubi9/python-312:latest
 WORKDIR /opt/app-root
 
-# Switch to root for package installation
-USER root
+RUN pip install uv
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
-RUN pip install \
+RUN uv pip install --upgrade \
+    'langchain>=0.3.25,<1.0.0'
+RUN uv pip install --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
+RUN uv pip install \
+    'datasets>=4.0.0' \
+    'mcp>=1.23.0' \
+    'pymilvus[milvus-lite]>=2.4.10' \
     aiosqlite \
     asyncpg \
     autoevals \
     chardet \
-    'datasets>=4.0.0' \
+    einops \
     fastapi \
     fire \
     httpx \
     matplotlib \
-    'mcp>=1.8.1' \
     nltk \
     numpy \
     opentelemetry-exporter-otlp-proto-http \
@@ -25,39 +29,41 @@ RUN pip install \
     pandas \
     pillow \
     psycopg2-binary \
-    'pymilvus[milvus-lite]>=2.4.10' \
     pymongo \
     pypdf \
     redis \
     requests \
+    safetensors \
     scikit-learn \
     scipy \
     sentencepiece \
     sqlalchemy[asyncio] \
+    tokenizers \
     tqdm \
     transformers \
     uvicorn
-RUN pip install \
-    llama_stack_provider_lmeval==0.2.4
-RUN pip install \
-    llama_stack_provider_ragas==0.3.0
-RUN pip install \
-    llama_stack_provider_ragas[remote]==0.3.0
-RUN pip install \
-    llama_stack_provider_trustyai_fms==0.2.2
-RUN pip install \
-    llama_stack_provider_trustyai_garak==0.1.4
-RUN pip install \
-    llama_stack_provider_trustyai_garak[remote]==0.1.4
-RUN pip install --extra-index-url https://download.pytorch.org/whl/cpu torch 'torchao>=0.12.0' torchvision
-RUN pip install --no-deps sentence-transformers
-RUN pip install --no-cache llama-stack==0.2.22
+RUN uv pip install \
+    llama_stack_provider_lmeval==0.4.1
+RUN uv pip install \
+    llama_stack_provider_ragas==0.5.1
+RUN uv pip install \
+    llama_stack_provider_ragas[remote]==0.5.1
+RUN uv pip install \
+    llama_stack_provider_trustyai_fms==0.3.1
+RUN uv pip install \
+    llama_stack_provider_trustyai_garak==0.1.6
+RUN uv pip install \
+    llama_stack_provider_trustyai_garak[remote]==0.1.6
+RUN uv pip install --no-deps sentence-transformers
+RUN pip install --no-cache llama-stack==0.3.4
 
-# chown the work directories to the non-root user to create garak scan log files
-RUN chown -R 1001:1001 ${APP_ROOT}
-# Switch back to non-root user
-USER 1001
+# # commenting to reduce image size
+# # chown the work directories to the non-root user to create garak scan log files
+# RUN chown -R 1001:1001 ${APP_ROOT}
+# # Switch back to non-root user
+# USER 1001
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY trustyai-distribution/run.yaml ${APP_ROOT}/run.yaml
+COPY --chmod=755 trustyai-distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh
 
-ENTRYPOINT ["python", "-m", "llama_stack.core.server.server", "/opt/app-root/run.yaml"]
+ENTRYPOINT ["/opt/app-root/entrypoint.sh"]

--- a/trustyai-distribution/Containerfile.in
+++ b/trustyai-distribution/Containerfile.in
@@ -1,17 +1,18 @@
 FROM registry.access.redhat.com/ubi9/python-312:latest
 WORKDIR /opt/app-root
 
-# Switch to root for package installation
-USER root
+RUN pip install uv
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
 {dependencies}
-RUN pip install --no-cache llama-stack==0.2.22
+RUN pip install --no-cache llama-stack==0.3.4
 
-# chown the work directories to the non-root user to create garak scan log files
-RUN chown -R 1001:1001 ${{APP_ROOT}}
-# Switch back to non-root user
-USER 1001
+# # commenting to reduce image size
+# # chown the work directories to the non-root user to create garak scan log files
+# RUN chown -R 1001:1001 ${{APP_ROOT}}
+# # Switch back to non-root user
+# USER 1001
 RUN mkdir -p ${{HOME}}/.llama ${{HOME}}/.cache
 COPY trustyai-distribution/run.yaml ${{APP_ROOT}}/run.yaml
+COPY --chmod=755 trustyai-distribution/entrypoint.sh ${{APP_ROOT}}/entrypoint.sh
 
-ENTRYPOINT ["python", "-m", "llama_stack.core.server.server", "/opt/app-root/run.yaml"]
+ENTRYPOINT ["/opt/app-root/entrypoint.sh"]

--- a/trustyai-distribution/build.py
+++ b/trustyai-distribution/build.py
@@ -11,11 +11,16 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+import shlex
 
 BASE_REQUIREMENTS = [
-    "llama-stack==0.2.22",
+    "llama-stack==0.3.4",
 ]
 
+# TODO: Add other pinned dependencies from odh lls-distro
+PINNED_DEPENDENCIES = [
+    "'langchain>=0.3.25,<1.0.0'",
+]
 
 def check_llama_installed():
     """Check if llama binary is installed and accessible."""
@@ -59,69 +64,121 @@ def check_llama_stack_version():
 
 def get_dependencies():
     """Execute the llama stack build command and capture dependencies."""
-    cmd = "llama stack build --config trustyai-distribution/build.yaml --print-deps-only"
+    cmd = "llama stack list-deps trustyai-distribution/build.yaml"
     try:
-        result = subprocess.run(cmd, shell=True, capture_output=True, text=True, check=True)
+        result = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True, check=True
+        )
         # Categorize and sort different types of pip install commands
         standard_deps = []
         torch_deps = []
         no_deps = []
         no_cache = []
+        ct = 1
 
         for line in result.stdout.splitlines():
-            if line.strip().startswith("uv pip"):
-                # Split the line into command and packages
-                parts = line.replace("uv ", "RUN ", 1).split(" ", 3)
+            line = line.strip()
+            if not line:  # Skip empty lines
+                continue
+
+            # Handle both "uv pip" format and direct package list format
+            if line.startswith("uv pip"):
+                # Legacy format: "uv pip install ..."
+                line = line.replace("uv ", "RUN ", 1)
+                parts = line.split(" ", 3)
                 if len(parts) >= 4:  # We have packages to sort
                     cmd_parts = parts[:3]  # "RUN pip install"
-                    packages = sorted(set(parts[3].split()))  # Sort the package names and remove duplicates
-
-                    # Add quotes to packages with > or < to prevent bash redirection
-                    packages = [
-                        f"'{package}'"
-                        if (">" in package or "<" in package)
-                        else package
-                        for package in packages
-                    ]
-
-                    # Modify pymilvus package to include milvus-lite extra
-                    packages = [
-                        package.replace("pymilvus", "pymilvus[milvus-lite]")
-                        if "pymilvus" in package
-                        else package
-                        for package in packages
-                    ]
-
-                    # Determine command type and format accordingly
-                    if ("--index-url" in line) or ("--extra-index-url" in line):
-                        full_cmd = " ".join(cmd_parts + [" ".join(packages)])
-                        torch_deps.append(full_cmd)
-                    elif "--no-deps" in line:
-                        full_cmd = " ".join(cmd_parts + [" ".join(packages)])
-                        no_deps.append(full_cmd)
-                    elif "--no-cache" in line:
-                        full_cmd = " ".join(cmd_parts + [" ".join(packages)])
-                        no_cache.append(full_cmd)
-                    else:
-                        formatted_packages = " \\\n    ".join(packages)
-                        full_cmd = f"{' '.join(cmd_parts)} \\\n    {formatted_packages}"
-                        standard_deps.append(full_cmd)
+                    packages_str = parts[3]
                 else:
                     standard_deps.append(" ".join(parts))
+                    continue
+            else:
+                # New format: just packages, possibly with flags
+                cmd_parts = ["RUN", "uv", "pip", "install"]
+                packages_str = line
+
+            # Parse packages and flags from the line
+            # Use shlex.split to properly handle quoted package names
+            parts_list = shlex.split(packages_str)
+            packages = []
+            flags = []
+            extra_index_url = None
+
+            i = 0
+            while i < len(parts_list):
+                if parts_list[i] == "--extra-index-url" and i + 1 < len(parts_list):
+                    extra_index_url = parts_list[i + 1]
+                    flags.extend([parts_list[i], parts_list[i + 1]])
+                    i += 2
+                elif parts_list[i] == "--index-url" and i + 1 < len(parts_list):
+                    flags.extend([parts_list[i], parts_list[i + 1]])
+                    i += 2
+                elif parts_list[i] in ["--no-deps", "--no-cache"]:
+                    flags.append(parts_list[i])
+                    i += 1
+                else:
+                    packages.append(parts_list[i])
+                    i += 1
+
+            # Sort and deduplicate packages
+            packages = sorted(set(packages))
+
+            # Add quotes to packages with > or < to prevent bash redirection
+            packages = [
+                f"'{package}'" if (">" in package or "<" in package) else package
+                for package in packages
+            ]
+
+            # Modify pymilvus package to include milvus-lite extra
+            packages = [
+                package.replace("pymilvus", "pymilvus[milvus-lite]")
+                if "pymilvus" in package and "[milvus-lite]" not in package
+                else package
+                for package in packages
+            ]
+            packages = sorted(set(packages))
+
+            # Build the command based on flags
+            if extra_index_url or "--index-url" in flags:
+                # Torch dependencies with extra index URL
+                full_cmd = " ".join(cmd_parts + flags + packages)
+                torch_deps.append(full_cmd)
+            elif "--no-deps" in flags:
+                full_cmd = " ".join(cmd_parts + flags + packages)
+                no_deps.append(full_cmd)
+            elif "--no-cache" in flags:
+                full_cmd = " ".join(cmd_parts + flags + packages)
+                no_cache.append(full_cmd)
+            else:
+                # Standard dependencies with multi-line formatting
+                formatted_packages = " \\\n    ".join(packages)
+                full_cmd = f"{' '.join(cmd_parts)} \\\n    {formatted_packages}"
+                standard_deps.append(full_cmd)
 
         # Combine all dependencies in specific order
         all_deps = []
-        all_deps.extend(sorted(standard_deps))  # Regular pip installs first
+
+        # Add pinned dependencies FIRST to ensure version compatibility
+        if PINNED_DEPENDENCIES:
+            pinned_packages = " \\\n    ".join(PINNED_DEPENDENCIES)
+            pinned_cmd = f"RUN uv pip install --upgrade \\\n    {pinned_packages}"
+            all_deps.append(pinned_cmd)
+
+        # torch_deps before standard_deps to make image way smaller
+        # because of cpu torch, else garak will install gpu (cuda) torch
         all_deps.extend(sorted(torch_deps))  # PyTorch specific installs
+        all_deps.extend(sorted(standard_deps))  # Regular pip installs
         all_deps.extend(sorted(no_deps))  # No-deps installs
         all_deps.extend(sorted(no_cache))  # No-cache installs
 
-        return "\n".join(all_deps)
+        result = "\n".join(all_deps)
+        return result
     except subprocess.CalledProcessError as e:
         print(f"Error executing command: {e}")
         print(f"Command output: {e.output}")
         print(f"Command stderr: {e.stderr}")
         sys.exit(1)
+
 
 
 def generate_containerfile(dependencies):

--- a/trustyai-distribution/build.yaml
+++ b/trustyai-distribution/build.yaml
@@ -9,20 +9,20 @@ distribution_spec:
     - provider_type: inline::milvus
     safety:
     - provider_type: remote::trustyai_fms
-      module: llama_stack_provider_trustyai_fms==0.2.2
+      module: llama_stack_provider_trustyai_fms==0.3.1
     agents:
     - provider_type: inline::meta-reference
     eval:
     - provider_type: remote::trustyai_lmeval
-      module: llama_stack_provider_lmeval==0.2.4
+      module: llama_stack_provider_lmeval==0.4.1
     - provider_type: inline::trustyai_garak
-      module: llama_stack_provider_trustyai_garak==0.1.4
+      module: llama_stack_provider_trustyai_garak==0.1.6
     - provider_type: remote::trustyai_garak
-      module: llama_stack_provider_trustyai_garak[remote]==0.1.4
+      module: llama_stack_provider_trustyai_garak[remote]==0.1.6
     - provider_type: inline::trustyai_ragas
-      module: llama_stack_provider_ragas==0.3.0
+      module: llama_stack_provider_ragas==0.5.1
     - provider_type: remote::trustyai_ragas
-      module: llama_stack_provider_ragas[remote]==0.3.0
+      module: llama_stack_provider_ragas[remote]==0.5.1
     datasetio:
     - provider_type: remote::huggingface
     - provider_type: inline::localfs
@@ -30,8 +30,6 @@ distribution_spec:
     - provider_type: inline::basic
     - provider_type: inline::llm-as-judge
     - provider_type: inline::braintrust
-    telemetry:
-    - provider_type: inline::meta-reference
     tool_runtime:
     - provider_type: remote::brave-search
     - provider_type: remote::tavily-search

--- a/trustyai-distribution/entrypoint.sh
+++ b/trustyai-distribution/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+if [ -n "$RUN_CONFIG_PATH" ] && [ -f "$RUN_CONFIG_PATH" ]; then
+  exec llama stack run "$RUN_CONFIG_PATH" "$@"
+fi
+
+if [ -n "$DISTRO_NAME" ]; then
+  exec llama stack run "$DISTRO_NAME" "$@"
+fi
+
+exec llama stack run /opt/app-root/run.yaml "$@"

--- a/trustyai-distribution/run.yaml
+++ b/trustyai-distribution/run.yaml
@@ -7,17 +7,16 @@ apis:
 - inference
 - safety
 - scoring
-- telemetry
 - tool_runtime
 - vector_io
 - files
 - benchmarks
 providers:
   inference:
-  - provider_id: vllm-inference
+  - provider_id: ${env.VLLM_URL:+vllm-inference}
     provider_type: remote::vllm
     config:
-      url: ${env.VLLM_URL:=http://localhost:8000/v1}
+      url: ${env.VLLM_URL}
       max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
       api_token: ${env.VLLM_API_TOKEN:=fake}
       tls_verify: ${env.VLLM_TLS_VERIFY:=true}
@@ -29,14 +28,13 @@ providers:
     provider_type: inline::milvus
     config:
       db_path: /opt/app-root/src/.llama/distributions/trustyai/milvus.db
-      kvstore:
-        type: sqlite
-        namespace: null
-        db_path: /opt/app-root/src/.llama/distributions/trustyai/milvus_registry.db
+      persistence:
+        backend: kv_milvus_inline
+        namespace: vector_io::milvus
   safety:
     - provider_id: trustyai_fms
       provider_type: remote::trustyai_fms
-      module: llama_stack_provider_trustyai_fms==0.2.2
+      module: llama_stack_provider_trustyai_fms
       config:
         orchestrator_url: ${env.FMS_ORCHESTRATOR_URL:=}
         ssl_cert_path: ${env.FMS_SSL_CERT_PATH:=}
@@ -45,17 +43,19 @@ providers:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
-      persistence_store:
-        type: sqlite
-        namespace: null
-        db_path: /opt/app-root/src/.llama/distributions/trustyai/agents_store.db
-      responses_store:
-        type: sqlite
-        db_path: /opt/app-root/src/.llama/distributions/trustyai/responses_store.db
+      persistence:
+        agent_state:
+          backend: kv_agents
+          namespace: agents::meta_reference
+        responses:
+          backend: sql_agents
+          table_name: agents_responses
+          max_write_queue_size: 10000
+          num_writers: 4
   eval:
   - provider_id: trustyai_lmeval
     provider_type: remote::trustyai_lmeval
-    module: llama_stack_provider_lmeval==0.2.4
+    module: llama_stack_provider_lmeval
     config:
         use_k8s: ${env.TRUSTYAI_LMEVAL_USE_K8S:=true}
         base_url: ${env.VLLM_URL:=http://localhost:8000/v1}
@@ -63,55 +63,54 @@ providers:
     provider_type: inline::trustyai_garak
     module: llama_stack_provider_trustyai_garak.inline
     config:
-      base_url: ${env.BASE_URL:=http://localhost:8321/v1} # llama-stack service base url
+      llama_stack_url: ${env.LLAMA_STACK_URL:=http://localhost:8321}
       timeout: ${env.GARAK_TIMEOUT:=10800}
       max_concurrent_jobs: ${env.GARAK_MAX_CONCURRENT_JOBS:=5}
       tls_verify: ${env.GARAK_TLS_VERIFY:=true}
-  - provider_id: trustyai_garak_remote
+  - provider_id: trustyai_garak
     provider_type: remote::trustyai_garak
     module: llama_stack_provider_trustyai_garak.remote
     config:
-      base_url: ${env.BASE_URL:=https://c11deb30887f.ngrok-free.app/v1} # llama-stack service base url (must be accessible from kf pods)
-      timeout: ${env.GARAK_TIMEOUT:=10800}
-      max_concurrent_jobs: ${env.GARAK_MAX_CONCURRENT_JOBS:=5}
+      llama_stack_url: ${env.KUBEFLOW_LLAMA_STACK_URL:=""}
       tls_verify: ${env.GARAK_TLS_VERIFY:=true}
       kubeflow_config:
-        pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT:=https://ds-pipeline-dspa-model-namespace.apps.rosa.y1m4j9o2e1n6b9l.r6mx.p3.openshiftapps.com}
-        namespace: ${env.KUBEFLOW_NAMESPACE:=model-namespace}
-        experiment_name: ${env.KUBEFLOW_EXPERIMENT_NAME:=trustyai-garak-scans}
-        base_image: ${env.KUBEFLOW_BASE_IMAGE:=quay.io/rh-ee-spandraj/trustyai-garak-provider-dsp:cpu}
+        results_s3_prefix: ${env.KUBEFLOW_RESULTS_S3_PREFIX:=""}
+        s3_credentials_secret_name: ${env.KUBEFLOW_S3_CREDENTIALS_SECRET_NAME:=""}
+        pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT:=""}
+        namespace: ${env.KUBEFLOW_NAMESPACE:=""}
+        base_image: ${env.KUBEFLOW_BASE_IMAGE:=""}
+        pipelines_api_token: ${env.KUBEFLOW_PIPELINES_TOKEN:=}
   - provider_id: trustyai_ragas
     provider_type: inline::trustyai_ragas
     module: llama_stack_provider_ragas.inline
     config:
-      embedding_model: ${env.EMBEDDING_MODEL}
+      embedding_model: ${env.EMBEDDING_MODEL:=}
   - provider_id: trustyai_ragas
     provider_type: remote::trustyai_ragas
-    module: llama_stack_provider_ragas
+    module: llama_stack_provider_ragas.remote
     config:
-      embedding_model: ${env.EMBEDDING_MODEL}
+      embedding_model: ${env.EMBEDDING_MODEL:=}
       kubeflow_config:
-        results_s3_prefix: ${env.KUBEFLOW_RESULTS_S3_PREFIX}
-        s3_credentials_secret_name: ${env.KUBEFLOW_S3_CREDENTIALS_SECRET_NAME}
-        pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT}
-        namespace: ${env.KUBEFLOW_NAMESPACE}
-        llama_stack_url: ${env.KUBEFLOW_LLAMA_STACK_URL}
-        base_image: ${env.KUBEFLOW_BASE_IMAGE}
+        results_s3_prefix: ${env.KUBEFLOW_RESULTS_S3_PREFIX:=}
+        s3_credentials_secret_name: ${env.KUBEFLOW_S3_CREDENTIALS_SECRET_NAME:=}
+        pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT:=}
+        namespace: ${env.KUBEFLOW_NAMESPACE:=}
+        llama_stack_url: ${env.KUBEFLOW_LLAMA_STACK_URL:=}
+        base_image: ${env.KUBEFLOW_BASE_IMAGE:=}
+        pipelines_api_token: ${env.KUBEFLOW_PIPELINES_TOKEN:=} # if not set, uses kubeconfig
   datasetio:
   - provider_id: huggingface
     provider_type: remote::huggingface
     config:
       kvstore:
-        type: sqlite
-        namespace: null
-        db_path: /opt/app-root/src/.llama/distributions/trustyai/huggingface_datasetio.db
+        backend: kv_datasetio_huggingface
+        namespace: datasetio::huggingface
   - provider_id: localfs
     provider_type: inline::localfs
     config:
       kvstore:
-        type: sqlite
-        namespace: null
-        db_path: /opt/app-root/src/.llama/distributions/trustyai/localfs_datasetio.db
+        backend: kv_datasetio_localfs
+        namespace: datasetio::localfs
   scoring:
   - provider_id: basic
     provider_type: inline::basic
@@ -123,14 +122,6 @@ providers:
     provider_type: inline::braintrust
     config:
       openai_api_key: ${env.OPENAI_API_KEY:=}
-  telemetry:
-  - provider_id: meta-reference
-    provider_type: inline::meta-reference
-    config:
-      service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
-      sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
-      sqlite_db_path: /opt/app-root/src/.llama/distributions/trustyai/trace_store.db
-      otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}
   tool_runtime:
   - provider_id: brave-search
     provider_type: remote::brave-search
@@ -154,71 +145,104 @@ providers:
     config:
       storage_dir: /opt/app-root/src/.llama/distributions/trustyai/files
       metadata_store:
-        type: sqlite
-        db_path: /opt/app-root/src/.llama/distributions/trustyai/registry.db
-metadata_store:
-  type: sqlite
-  db_path: /opt/app-root/src/.llama/distributions/trustyai/registry.db
-inference_store:
-  type: sqlite
-  db_path: /opt/app-root/src/.llama/distributions/trustyai/inference_store.db
-models:
-- metadata: {}
-  model_id: ${env.INFERENCE_MODEL}
-  provider_id: vllm-inference
-  model_type: llm
-- metadata:
-    embedding_dimension: 768
-  model_id: granite-embedding-125m
-  provider_id: sentence-transformers
-  provider_model_id: ibm-granite/granite-embedding-125m-english
-  model_type: embedding
-shields: []
-vector_dbs: []
-datasets: []
-scoring_fns: []
-benchmarks: # TODO: Can a single benchmark be used for both inline and remote garak providers?
-- benchmark_id: trustyai_garak::quick
-  dataset_id: garak
-  scoring_functions:
-    - garak_scoring
-  provider_id: trustyai_garak_remote
-  provider_benchmark_id: quick
-- benchmark_id: trustyai_garak::standard
-  dataset_id: garak
-  scoring_functions:
-    - garak_scoring
-  provider_id: trustyai_garak_remote
-  provider_benchmark_id: standard
-- benchmark_id: trustyai_garak::owasp_llm_top10
-  dataset_id: garak
-  scoring_functions:
-    - garak_scoring
-  provider_id: trustyai_garak_remote
-  provider_benchmark_id: owasp_llm_top10
-- benchmark_id: trustyai_garak::avid_security
-  dataset_id: garak
-  scoring_functions:
-    - garak_scoring
-  provider_id: trustyai_garak_remote
-  provider_benchmark_id: avid_security
-- benchmark_id: trustyai_garak::avid_ethics
-  dataset_id: garak
-  scoring_functions:
-    - garak_scoring
-  provider_id: trustyai_garak_remote
-  provider_benchmark_id: avid_ethics
-- benchmark_id: trustyai_garak::avid_performance
-  dataset_id: garak
-  scoring_functions:
-    - garak_scoring
-  provider_id: trustyai_garak_remote
-  provider_benchmark_id: avid_performance
-tool_groups:
-- toolgroup_id: builtin::websearch
-  provider_id: tavily-search
-- toolgroup_id: builtin::rag
-  provider_id: rag-runtime
+        backend: sql_files
+        table_name: files_metadata
+storage:
+  backends:
+    kv_default:
+      type: kv_sqlite
+      db_path: /opt/app-root/src/.llama/distributions/trustyai/kvstore.db
+    kv_agents:
+      type: kv_sqlite
+      db_path: /opt/app-root/src/.llama/distributions/trustyai/agents_store.db
+    kv_milvus_inline:
+      type: kv_sqlite
+      db_path: /opt/app-root/src/.llama/distributions/trustyai/milvus_inline_registry.db
+    kv_datasetio_huggingface:
+      type: kv_sqlite
+      db_path: /opt/app-root/src/.llama/distributions/trustyai/huggingface_datasetio.db
+    kv_datasetio_localfs:
+      type: kv_sqlite
+      db_path: /opt/app-root/src/.llama/distributions/trustyai/localfs_datasetio.db
+    sql_default:
+      type: sql_sqlite
+      db_path: /opt/app-root/src/.llama/distributions/trustyai/sql_store.db
+    sql_agents:
+      type: sql_sqlite
+      db_path: /opt/app-root/src/.llama/distributions/trustyai/responses_store.db
+    sql_files:
+      type: sql_sqlite
+      db_path: /opt/app-root/src/.llama/distributions/trustyai/files_metadata.db
+  stores:
+    metadata:
+      namespace: registry
+      backend: kv_default
+    inference:
+      table_name: inference_store
+      backend: sql_default
+      max_write_queue_size: 10000
+      num_writers: 4
+    conversations:
+      table_name: openai_conversations
+      backend: sql_default
+registered_resources:
+  models:
+  - metadata: {}
+    model_id: ${env.INFERENCE_MODEL}
+    provider_id: vllm-inference
+    model_type: llm
+  - metadata:
+      embedding_dimension: 768
+    model_id: granite-embedding-125m
+    provider_id: sentence-transformers
+    provider_model_id: ibm-granite/granite-embedding-125m-english
+    model_type: embedding
+  shields: []
+  vector_dbs: []
+  datasets: []
+  scoring_fns: []
+  benchmarks: # TODO: Can a single benchmark be used for both inline and remote garak providers?
+  - benchmark_id: trustyai_garak::owasp_llm_top10
+    dataset_id: garak
+    scoring_functions:
+      - garak_scoring
+    provider_id: trustyai_garak
+    provider_benchmark_id: owasp_llm_top10
+  - benchmark_id: trustyai_garak::avid_security
+    dataset_id: garak
+    scoring_functions:
+      - garak_scoring
+    provider_id: trustyai_garak
+    provider_benchmark_id: avid_security
+  - benchmark_id: trustyai_garak::avid_ethics
+    dataset_id: garak
+    scoring_functions:
+      - garak_scoring
+    provider_id: trustyai_garak
+    provider_benchmark_id: avid_ethics
+  - benchmark_id: trustyai_garak::avid_performance
+    dataset_id: garak
+    scoring_functions:
+      - garak_scoring
+    provider_id: trustyai_garak
+    provider_benchmark_id: avid_performance
+  - benchmark_id: trustyai_garak::quick
+    dataset_id: garak
+    scoring_functions:
+      - garak_scoring
+    provider_id: trustyai_garak
+    provider_benchmark_id: quick
+  - benchmark_id: trustyai_garak::standard
+    dataset_id: garak
+    scoring_functions:
+      - garak_scoring
+    provider_id: trustyai_garak
+    provider_benchmark_id: standard
+  tool_groups:
+  - toolgroup_id: builtin::websearch
+    provider_id: tavily-search
+  - toolgroup_id: builtin::rag
+    provider_id: rag-runtime
 server:
   port: 8321
 # external_providers_dir: /opt/app-root/src/.llama/providers.d


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
This PR updated the TrustyAI Llama Stack distro with latest versions of TrustyAI providers and LLS.
<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
Built the image and manually tested the functionality of 1 provider (garak; both inline & remote). The distro image tested is available at `quay.io/rh-ee-spandraj/trustyai-lls-distro:lls-0.3.4`

## Summary by Sourcery

Update the TrustyAI Llama Stack distribution to Llama Stack 0.3.4 and align providers, storage, and container build with the latest LLS conventions.

New Features:
- Introduce a flexible entrypoint script that selects the run configuration via RUN_CONFIG_PATH, DISTRO_NAME, or a default path.
- Add centralized storage backend and store definitions for metadata, inference, conversations, and provider-specific persistence.

Bug Fixes:
- Prevent unwanted installation of CUDA-enabled torch by prioritizing CPU torch dependencies in the generated Containerfile.
- Avoid misconfiguration of pymilvus by consistently installing the milvus-lite extra when needed.

Enhancements:
- Refresh provider versions for TrustyAI FMS, LMEval, Ragas, and Garak and update build metadata accordingly.
- Refactor run configuration to use new persistence namespaces, kv/sql backends, and registered_resources layout while dropping deprecated telemetry settings.
- Modernize dependency resolution by switching to `llama stack list-deps`, supporting both legacy and new formats, and using uv for pip installs with pinned langchain.
- Simplify vLLM and provider configuration to rely on explicit environment variables and updated parameter names.