### PR TITLE
Update TrustyAI distro with latest garak

### DIFF
--- a/trustyai-distribution/Containerfile
+++ b/trustyai-distribution/Containerfile
@@ -4,10 +4,20 @@
 FROM registry.access.redhat.com/ubi9/python-312:latest
 WORKDIR /opt/app-root
 
+# Switch to root for package installation
+USER root
+
 RUN pip install uv
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
 RUN uv pip install --upgrade \
-    'langchain>=0.3.25,<1.0.0'
+    'langchain>=0.3.25,<1.0.0' \
+    'kfp-kubernetes==2.14.6' \
+    'pyarrow>=21.0.0' \
+    'botocore==1.35.88' \
+    'boto3==1.35.88' \
+    'aiobotocore==2.16.1' \
+    'ibm-cos-sdk-core==2.14.2' \
+    'ibm-cos-sdk==2.14.2'
 RUN uv pip install --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
 RUN uv pip install \
     'datasets>=4.0.0' \
@@ -51,17 +61,17 @@ RUN uv pip install \
 RUN uv pip install \
     llama_stack_provider_trustyai_fms==0.3.1
 RUN uv pip install \
-    llama_stack_provider_trustyai_garak==0.1.6
+    llama_stack_provider_trustyai_garak==0.1.7
 RUN uv pip install \
-    llama_stack_provider_trustyai_garak[remote]==0.1.6
+    llama_stack_provider_trustyai_garak[inline]==0.1.7
 RUN uv pip install --no-deps sentence-transformers
 RUN pip install --no-cache llama-stack==0.3.4
 
-# # commenting to reduce image size
-# # chown the work directories to the non-root user to create garak scan log files
-# RUN chown -R 1001:1001 ${APP_ROOT}
+RUN mkdir -p ${APP_ROOT}/src/.llama/distributions/trustyai
+RUN chown -R 1001:1001 ${APP_ROOT}/src/.llama/distributions/trustyai
+
 # # Switch back to non-root user
-# USER 1001
+USER 1001
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY trustyai-distribution/run.yaml ${APP_ROOT}/run.yaml
 COPY --chmod=755 trustyai-distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh

--- a/trustyai-distribution/Containerfile.in
+++ b/trustyai-distribution/Containerfile.in
@@ -1,16 +1,19 @@
 FROM registry.access.redhat.com/ubi9/python-312:latest
 WORKDIR /opt/app-root
 
+# Switch to root for package installation
+USER root
+
 RUN pip install uv
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
 {dependencies}
 RUN pip install --no-cache llama-stack==0.3.4
 
-# # commenting to reduce image size
-# # chown the work directories to the non-root user to create garak scan log files
-# RUN chown -R 1001:1001 ${{APP_ROOT}}
+RUN mkdir -p ${{APP_ROOT}}/src/.llama/distributions/trustyai
+RUN chown -R 1001:1001 ${{APP_ROOT}}/src/.llama/distributions/trustyai
+
 # # Switch back to non-root user
-# USER 1001
+USER 1001
 RUN mkdir -p ${{HOME}}/.llama ${{HOME}}/.cache
 COPY trustyai-distribution/run.yaml ${{APP_ROOT}}/run.yaml
 COPY --chmod=755 trustyai-distribution/entrypoint.sh ${{APP_ROOT}}/entrypoint.sh

--- a/trustyai-distribution/build.py
+++ b/trustyai-distribution/build.py
@@ -17,9 +17,16 @@ BASE_REQUIREMENTS = [
     "llama-stack==0.3.4",
 ]
 
-# TODO: Add other pinned dependencies from odh lls-distro
+# pinned dependencies from odh lls-distro
 PINNED_DEPENDENCIES = [
     "'langchain>=0.3.25,<1.0.0'",
+    "'kfp-kubernetes==2.14.6'",
+    "'pyarrow>=21.0.0'",
+    "'botocore==1.35.88'",
+    "'boto3==1.35.88'",
+    "'aiobotocore==2.16.1'",
+    "'ibm-cos-sdk-core==2.14.2'",
+    "'ibm-cos-sdk==2.14.2'",
 ]
 
 def check_llama_installed():

--- a/trustyai-distribution/build.yaml
+++ b/trustyai-distribution/build.yaml
@@ -16,9 +16,9 @@ distribution_spec:
     - provider_type: remote::trustyai_lmeval
       module: llama_stack_provider_lmeval==0.4.1
     - provider_type: inline::trustyai_garak
-      module: llama_stack_provider_trustyai_garak==0.1.6
+      module: llama_stack_provider_trustyai_garak[inline]==0.1.7
     - provider_type: remote::trustyai_garak
-      module: llama_stack_provider_trustyai_garak[remote]==0.1.6
+      module: llama_stack_provider_trustyai_garak==0.1.7
     - provider_type: inline::trustyai_ragas
       module: llama_stack_provider_ragas==0.5.1
     - provider_type: remote::trustyai_ragas

--- a/trustyai-distribution/run.yaml
+++ b/trustyai-distribution/run.yaml
@@ -74,8 +74,6 @@ providers:
       llama_stack_url: ${env.KUBEFLOW_LLAMA_STACK_URL:=""}
       tls_verify: ${env.GARAK_TLS_VERIFY:=true}
       kubeflow_config:
-        results_s3_prefix: ${env.KUBEFLOW_RESULTS_S3_PREFIX:=""}
-        s3_credentials_secret_name: ${env.KUBEFLOW_S3_CREDENTIALS_SECRET_NAME:=""}
         pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT:=""}
         namespace: ${env.KUBEFLOW_NAMESPACE:=""}
         base_image: ${env.KUBEFLOW_BASE_IMAGE:=""}
@@ -85,7 +83,7 @@ providers:
     module: llama_stack_provider_ragas.inline
     config:
       embedding_model: ${env.EMBEDDING_MODEL:=}
-  - provider_id: trustyai_ragas
+  - provider_id: ${env.ENABLE_RAGAS:+trustyai_ragas}
     provider_type: remote::trustyai_ragas
     module: llama_stack_provider_ragas.remote
     config:


### PR DESCRIPTION
This PR updates the garak provider with latest version and corresponding changes. 

Built the image and manually tested the functionality of 1 provider (garak; both inline & remote). The distro image tested is available at - `quay.io/rh-ee-spandraj/trustyai-lls-distro:lls-0.3.4-latest`

## Summary by Sourcery

Update the TrustyAI distribution container and configuration to use the latest garak providers and align pinned dependencies and runtime settings with the ODH LLM distribution.

New Features:
- Add support for additional data and cloud integration dependencies (KFP, PyArrow, AWS and IBM COS SDKs) in the TrustyAI distribution image.

Enhancements:
- Switch container build to install packages as root while ensuring application directories are owned by the non-root runtime user.
- Update trustyai garak provider modules to version 0.1.7 and correct inline/remote module variants across container, build spec, and runtime config.
- Make the remote TrustyAI RAGAS provider conditionally enabled via an environment variable flag in the runtime configuration.
- Simplify Kubeflow garak configuration by removing unused S3-related settings.

Build:
- Pin new shared dependencies in the Python build script to stay consistent with the container image and ODH distro.